### PR TITLE
Refactor: rostpen script

### DIFF
--- a/src/ropsten.js
+++ b/src/ropsten.js
@@ -3,31 +3,12 @@
   Usage example:
 
   ```
-    $ node debug ropsten
-    < Debugger listening on [::]:5858
-    connecting to 127.0.0.1:5858 ... ok
-    break in ropsten.js:11
-      9
-     10
-    >11 var Registrar = require('./index.js')
-     12 var ENS = require('ethereum-ens');
-     13 var fs = require('fs');
-
-    // the program will stop here, enter `c` to 'continue' or 'help'
-    > c
-
-    break in ropsten.js:64
-     62   const registrar = new Registrar(web3);
-     63   const ens = registrar.ens; // eslint-disable-line
-    >64   debugger; // eslint-disable-line
-     65 });
-     66
-
-    // The program stops again, enter `repl` to access the program's environment
-    > repl
-
-    Press Ctrl + C to leave debug repl
-    > registrar.getEntry('insurance')
+    # In one terminal:
+    $ geth -testnet --rpc
+    # After the above has synced, in another terminal:
+    $ node ropsten
+    node>
+    node> registrar.getEntry('insurance')
     { name: 'insurance',
       hash: '0x73079a5cb4c7d259f40c6d0841629e689d2a95b85883b371e075ffb2f329c3e1',
       status: 2,
@@ -45,17 +26,20 @@
 
 const Registrar = require('./index.js');
 const Web3 = require('web3');
+const repl = require('repl');
 
 const web3 = new Web3();
 web3.setProvider(new web3.providers.HttpProvider('http://localhost:8545'));
-
 // TODO: make this into a proper repl
 web3.eth.getAccounts((err, accts) => { // eslint-disable-line
-
-  if (err) console.log(err); // eslint-disable-line
-  // ens = new ENS(web3);
-  const registrar = new Registrar(web3);
-  const ens = registrar.ens; // eslint-disable-line
-  debugger; // eslint-disable-line
+  if (err) { console.log(err); } // eslint-disable-line
+  else {
+    const registrar = new Registrar(web3);
+    const ens = registrar.ens; // eslint-disable-line
+    let r = repl.start('node> ');
+    r.context.registrar = registrar;
+    r.context.ens = ens;
+    r.context.web3 = web3;
+    r.context.accts = accts;
+  }
 });
-


### PR DESCRIPTION
Type of change:
===============
- Refactor

What changed? ... and Why:
==========================
The previous command required you to run `node debug rostpen`, and then
`continue` followed by `repl`.

This simplifies the rostpen repl, by allowing you to just run:
```
node rostpen
```

How has it been tested:
=======================
Locally