### PR TITLE
Change <= minLength to < minLength

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ Registrar.SpecialCharacters = Error(
 );
 
 Registrar.prototype.validateName = function validateName(name) {
-  if (name.length <= this.minLength) {
+  if (name.length < this.minLength) {
     throw Registrar.TooShort;
   }
   if (name !== cleanName(name)) {


### PR DESCRIPTION
Fixes incorrectly invalidating names with minimum length required (7 as of now)